### PR TITLE
less crashes and preserve rotation navigating images.

### DIFF
--- a/source/SDL_helper.c
+++ b/source/SDL_helper.c
@@ -39,7 +39,7 @@ int SDL_HelperInit(void) {
 	int flags = IMG_INIT_JPG | IMG_INIT_PNG;
 	if ((IMG_Init(flags) & flags) != flags) {
 		if (config.dev_options)
-			DEBUG_LOG("IMG_Init failed: %s", IMG_GetError());
+			DEBUG_LOG("IMG_Init failed: %s\n", IMG_GetError());
 		
 		return -1;
 	}
@@ -115,7 +115,7 @@ void SDL_LoadImage(SDL_Texture **texture, char *path) {
 	image = IMG_Load(path);
 	if (!image) {
 		if (config.dev_options)
-			DEBUG_LOG("IMG_Load failed: %s", IMG_GetError());
+			DEBUG_LOG("IMG_Load failed: %s\n", IMG_GetError());
 		
 		return;
 	}
@@ -123,6 +123,7 @@ void SDL_LoadImage(SDL_Texture **texture, char *path) {
 	SDL_ConvertSurfaceFormat(image, SDL_PIXELFORMAT_RGBA8888, 0);
 	*texture = SDL_CreateTextureFromSurface(RENDERER, image);
 	SDL_FreeSurface(image);
+	image = NULL;
 }
 
 void SDL_LoadImageMem(SDL_Texture **texture, void *data, int size) {
@@ -131,7 +132,7 @@ void SDL_LoadImageMem(SDL_Texture **texture, void *data, int size) {
 	image = IMG_Load_RW(SDL_RWFromMem(data, size), 1);
 	if (!image) {
 		if (config.dev_options)
-			DEBUG_LOG("IMG_Load_RW failed: %s", IMG_GetError());
+			DEBUG_LOG("IMG_Load_RW failed: %s\n", IMG_GetError());
 		
 		return;
 	}
@@ -139,6 +140,7 @@ void SDL_LoadImageMem(SDL_Texture **texture, void *data, int size) {
 	SDL_ConvertSurfaceFormat(image, SDL_PIXELFORMAT_RGBA8888, 0);
 	*texture = SDL_CreateTextureFromSurface(RENDERER, image);
 	SDL_FreeSurface(image);
+	image = NULL;
 }
 
 void SDL_DrawImage(SDL_Texture *texture, int x, int y) {

--- a/source/menus/menu_gallery.c
+++ b/source/menus/menu_gallery.c
@@ -114,10 +114,13 @@ void Gallery_DisplayGif(char *path) {
 	}
 
 	CEV_gifAnimFree(animation);
+
+	SDL_DestroyTexture(texture);
+	texture = NULL;
 }
 
 void Gallery_DisplayImage(char *path) {
-	Gallery_GetImageList();
+	Gallery_GetImageList();	
 	selection = Gallery_GetCurrentIndex(path);
 	SDL_LoadImage(&image, path);
 	SDL_QueryTexture(image, NULL, NULL, &width, &height);
@@ -157,13 +160,9 @@ void Gallery_DisplayImage(char *path) {
 		u64 kHeld = hidKeysHeld(CONTROLLER_P1_AUTO);
 
 		if ((kDown & KEY_DLEFT) || (kDown & KEY_L)) {
-			degrees = 0;
-			flip_type = SDL_FLIP_NONE;
 			Gallery_HandleNext(false);
 		}
 		else if ((kDown & KEY_DRIGHT) || (kDown & KEY_R)) {
-			degrees = 0;
-			flip_type = SDL_FLIP_NONE;
 			Gallery_HandleNext(true);
 		}
 
@@ -238,13 +237,9 @@ void Gallery_DisplayImage(char *path) {
 		
 		if (touchInfo.state == TouchEnded && touchInfo.tapType != TapNone) {
 			if (tapped_inside(touchInfo, 0, 0, 120, 720)) {
-				degrees = 0;
-				flip_type = SDL_FLIP_NONE;
 				Gallery_HandleNext(false);
 			}
 			else if (tapped_inside(touchInfo, 1160, 0, 1280, 720)) {
-				degrees = 0;
-				flip_type = SDL_FLIP_NONE;
 				Gallery_HandleNext(true);
 			}
 		}
@@ -260,7 +255,8 @@ void Gallery_DisplayImage(char *path) {
 
 	SDL_DestroyTexture(image);
 	image = NULL;
-	memset(album, 0, sizeof(album[0][0]) * 512 * 512);
+	memset(album, 0, sizeof(album));
 	count = 0;
+	selection = 0;
 	MENU_DEFAULT_STATE = MENU_STATE_HOME;
 }

--- a/source/menus/menu_music.c
+++ b/source/menus/menu_music.c
@@ -314,7 +314,7 @@ void Menu_PlayMusic(char *path) {
 	free(position_time);
 
 	Audio_Term();
-	memset(playlist, 0, sizeof(playlist[0][0]) * 512 * 512);
+	memset(playlist, 0, sizeof(playlist));
 	count = 0;
 	MENU_DEFAULT_STATE = MENU_STATE_HOME;
 }


### PR DESCRIPTION
I deleted the initialization of the rotation when changing images to make it more comfortable to navigate a folder of rotated images.
With this changes I'm able to view ~30 images before crash, before I could see ~10.
Also I added some /n to the error logs for clarity.