### PR TITLE
travis: fetch deps from dkp-pacman repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - docker pull devkitpro/devkita64
 script:
 - docker run -e ENABLE_COMPATIBILITY_REPORTING -v $TRAVIS_BUILD_DIR:/NX-Shell
-  devkitpro/devkita64 /bin/bash -ex /NX-Shell/.travis/.build.sh
+  ubuntu:18.10 /bin/bash -ex /NX-Shell/.travis/.build.sh
 
 deploy:
   provider: pages

--- a/.travis/.build.sh
+++ b/.travis/.build.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -ex
 
-sudo apt-get update -y
-sudo apt-get -y install build-essential
+apt-get update -y && apt-get -y install sudo
+sudo apt-get -y install build-essential sudo wget libxml2
+
+# install dkp deps
+touch /trustdb.gpg
+wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
+sudo dpkg -i devkitpro-pacman.deb
+
+sudo dkp-pacman --noconfirm -Syu switch-dev switch-sdl2 switch-sdl2_gfx switch-sdl2_image switch-sdl2_ttf switch-opusfile switch-liblzma switch-libvorbisidec switch-mpg123 switch-flac 
+
 source /etc/profile.d/devkit-env.sh
 export DEVKITA64=/opt/devkitpro/devkitA64
 


### PR DESCRIPTION
This PR uses the ubuntu docker image to fetches/installs dkp-pacman + deps directly, based on the info in the readme