### PR TITLE
travis: ubuntu 18.10 -> 18.04 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - docker pull devkitpro/devkita64
 script:
 - docker run -e ENABLE_COMPATIBILITY_REPORTING -v $TRAVIS_BUILD_DIR:/NX-Shell
-  ubuntu:18.10 /bin/bash -ex /NX-Shell/.travis/.build.sh
+  ubuntu:18.04 /bin/bash -ex /NX-Shell/.travis/.build.sh
 
 deploy:
   provider: pages


### PR DESCRIPTION
If you receive the following error from Travis:
```
24 Err:3 http://security.ubuntu.com/ubuntu cosmic-security Release
25   404  Not Found [IP: 91.189.88.149 80]
```

Switching from ubuntu 18.10 to the Long Term Support version 18.04 resolves it. According to [this page](https://ubuntu.com/about/release-cycle), it's supported until 2025– I haven't tried newer versions yet.