### PR TITLE
Fixed crash when pressing Y in an empty directory

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -119,12 +119,14 @@ namespace GUI {
 					}
 					else if (button == SDL_KEY_Y) {
 						if (item.state == MENU_STATE_FILEBROWSER) {
-							if ((!item.checked_cwd.empty()) && (item.checked_cwd.compare(config.cwd) != 0))
-								GUI::ResetCheckbox();
+							if (item.selected < static_cast<int>(item.checked.size())) {
+								if ((!item.checked_cwd.empty()) && (item.checked_cwd.compare(config.cwd) != 0))
+									GUI::ResetCheckbox();
 								
-							item.checked_cwd = config.cwd;
-							item.checked.at(item.selected) = !item.checked.at(item.selected);
-							item.checked_count = std::count(item.checked.begin(), item.checked.end(), true);
+								item.checked_cwd = config.cwd;
+								item.checked.at(item.selected) = !item.checked.at(item.selected);
+								item.checked_count = std::count(item.checked.begin(), item.checked.end(), true);
+							}
 						}
 					}
 					else if (button == SDL_KEY_DLEFT) {


### PR DESCRIPTION
**Fixed**
* #100

**Note**
my changes are based on https://github.com/joel16/NX-Shell/commit/6de0623826a35382cc958a09d8363e378297e3fd because I was unable to launch https://github.com/joel16/NX-Shell/commit/79850fb5b63a70c6b1bb6b135a48575beb91c432 and https://github.com/joel16/NX-Shell/commit/c36f52cd18ac12c513c7e539e4695fa1e857216f without crashing.