### PR TITLE
Fixed crash when pressing Y in an empty directory

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -118,12 +118,14 @@ namespace GUI {
 					}
 					else if (button == SDL_KEY_Y) {
 						if (item.state == MENU_STATE_FILEBROWSER) {
-							if ((!item.checked_cwd.empty()) && (item.checked_cwd.compare(cfg.cwd) != 0))
-								GUI::ResetCheckbox();
+							if (item.selected < static_cast<int>(item.checked.size())) {
+								if ((!item.checked_cwd.empty()) && (item.checked_cwd.compare(cfg.cwd) != 0))
+									GUI::ResetCheckbox();
 								
-							item.checked_cwd = cfg.cwd;
-							item.checked.at(item.selected) = !item.checked.at(item.selected);
-							item.checked_count = std::count(item.checked.begin(), item.checked.end(), true);
+								item.checked_cwd = cfg.cwd;
+								item.checked.at(item.selected) = !item.checked.at(item.selected);
+								item.checked_count = std::count(item.checked.begin(), item.checked.end(), true);
+							}
 						}
 					}
 					else if (button == SDL_KEY_DLEFT) {


### PR DESCRIPTION
**Fix**
* #100

**Note**
I was only able to get c36f52c to launch without crashing in app mode.
https://github.com/zand/NX-Shell/tree/iss100 has the fix applied to 6de0623 witch is the last commit I was able to get running in applet mode. 